### PR TITLE
refactor: use plugin with swc parse api

### DIFF
--- a/.changeset/few-timers-reply.md
+++ b/.changeset/few-timers-reply.md
@@ -1,0 +1,5 @@
+---
+"@macro-plugin/webpack": minor
+---
+
+refactor: use plugin with swc parse api

--- a/.changeset/purple-bottles-taste.md
+++ b/.changeset/purple-bottles-taste.md
@@ -1,0 +1,5 @@
+---
+"@macro-plugin/rollup": minor
+---
+
+refactor: use plugin with swc parse api

--- a/.changeset/rotten-spiders-refuse.md
+++ b/.changeset/rotten-spiders-refuse.md
@@ -1,0 +1,5 @@
+---
+"@macro-plugin/register": patch
+---
+
+refactor: use plugin with swc parse api

--- a/.changeset/seven-windows-rule.md
+++ b/.changeset/seven-windows-rule.md
@@ -1,0 +1,5 @@
+---
+"@macro-plugin/jest": minor
+---
+
+refactor: use plugin with swc parse api

--- a/.changeset/small-mice-repair.md
+++ b/.changeset/small-mice-repair.md
@@ -1,0 +1,5 @@
+---
+"@macro-plugin/vite": minor
+---
+
+refactor: use plugin with swc parse api

--- a/packages/core/tests/__snapshots__/literal.test.ts.snap
+++ b/packages/core/tests/__snapshots__/literal.test.ts.snap
@@ -103,3 +103,11 @@ exports[`use as swc plugin 1`] = `
 }
 "
 `;
+
+exports[`use with swc transform ast 1`] = `
+"var a = "Hello";
+if (true) {
+    console.log("development");
+}
+"
+`;

--- a/packages/core/tests/literal.test.ts
+++ b/packages/core/tests/literal.test.ts
@@ -1,6 +1,5 @@
 import { createLitMacro, createSwcPlugin, parseExpr, transform } from "../src"
-
-import { transformSync as swcTransform } from "@swc/core"
+import { parseSync, transformSync as swcTransform } from "@swc/core"
 
 test("create literal macro", () => {
   const code = `
@@ -22,6 +21,22 @@ test("use as swc plugin", () => {
   `
 
   expect(swcTransform(code, { plugin, jsc: { parser: { syntax: "typescript" } } }).code).toMatchSnapshot()
+})
+
+test("use with swc transform ast", () => {
+  const plugin = createSwcPlugin({ macros: [createLitMacro("__DEV__", true)] })
+
+  const code = `
+  let a: string = "Hello"
+
+  if (__DEV__) {
+    console.log('development')
+  }
+  `
+
+  const program = plugin(parseSync(code, { syntax: "typescript" }))
+
+  expect(swcTransform(program, { jsc: { parser: { syntax: "typescript" } } }).code).toMatchSnapshot()
 })
 
 test("should pass overwrited variable", () => {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,6 +1,6 @@
 import { Config, createSwcPlugin, getSpanOffset, transformAsync } from "@macro-plugin/core"
 import { SCRIPT_EXTENSIONS, buildTransformOptions, createFilter, createResolver, getHasModuleSideEffects, getIdMatcher, matchScriptType, patchTsOptions, resolveTsOptions } from "@macro-plugin/shared"
-import { minify as swcMinify, transform as swcTransform } from "@swc/core"
+import { minify as swcMinify, parse as swcParse, transform as swcTransform } from "@swc/core"
 
 import type { Plugin } from "vite"
 import type { TreeshakingOptions } from "rollup"
@@ -24,17 +24,16 @@ async function viteMacroPlugin (config?: Config): Promise<Plugin> {
 
       const { isTypeScript, isJsx, isTsx } = target
 
-      // use macro as swc plugin when using typescript or jsx
+      // use swc transform typescript and jsx
       if (isTypeScript || isJsx) {
-        const plugin = createSwcPlugin(macroOptions, code, getSpanOffset())
+        const macroPlugin = createSwcPlugin(macroOptions, code, getSpanOffset())
         const swcOptions = patchTsOptions({
           ...basicSwcOptions,
-          plugin,
           filename: id,
           minify: false
         }, macroOptions.tsconfig === false ? undefined : resolveTsOptions(dirname(id), macroOptions.tsconfig), isTypeScript, isTsx, isJsx)
-
-        return await swcTransform(code, swcOptions)
+        const program = await swcParse(code, swcOptions.jsc?.parser || { syntax: "typescript" })
+        return await swcTransform(macroPlugin(program), swcOptions)
       }
 
       // native macro transform without swc


### PR DESCRIPTION
No longer use native swc plugin option, use plugin call instead.